### PR TITLE
Update Nissan Altima generations: add Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,6 @@
 
 This repository contains signal set configurations for the Nissan Altima, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Nissan Altima.
 
-## Generations
-
-The Nissan Altima has gone through six main generations since its introduction:
-
-- **First Generation (1993-1997)**: Initially launched as the "Stanza Altima" to replace the Nissan Stanza. It was powered by a 150 hp straight-4 DOHC engine with either a five-speed manual or four-speed automatic transmission. This generation offered multiple trim levels including XE (base), GXE, SE (sporty), and GLE (luxury). The top-tier GLE trim featured advanced technology for its time, including a heads-up display on 1993-1994 models.
-
-- **Second Generation (1998-2001)**: This shorter-lived generation was designed specifically for the American market at Nissan's California design center. It featured a more powerful 155 hp engine and improved interior space. Side airbags were introduced as a safety feature, and the GLE luxury trim now came with standard leather seating. Trim levels remained XE, GXE, SE, and GLE.
-
-- **Third Generation (2002-2006)**: This was the first mass-market Altima built on Nissan's new FF-L platform and represented a significant departure from previous generations. It grew substantially in size with interior volume expanding to 118.8 cubic feet. This generation introduced the first V6 engine option - a 3.5-liter producing initially 240 hp (later 250 hp), alongside the 2.5-liter four-cylinder producing 175 hp. The 2005 model received a facelift with a new front grille, all-red taillights, and redesigned interior.
-
-- **Fourth Generation (2007-2012)**: This generation brought significant changes including the introduction of a coupe body style and more modern exterior styling. Engine choices remained similar to the third generation with a 2.5-liter four-cylinder and an upgraded 3.5-liter V6 now producing 270 hp. A continuously variable transmission (CVT) became available as an option. The 2010 model received a minor facelift with revised headlights and grille, and electronic stability control became standard.
-
-- **Fifth Generation (2013-2018)**: This Altima featured a more aerodynamic and rigid body design. The 2.5-liter engine was uprated to 182 hp while the 3.5-liter V6 remained at 270 hp. Fuel economy was significantly improved thanks to a redesigned CVT. Notable features included NASA-inspired "zero-gravity" seats designed to reduce driver fatigue. This generation was the first to completely drop the manual transmission option.
-
-- **Sixth Generation (2019-present)**: Unveiled at the 2018 New York International Auto Show, this generation is slightly longer, lower, and wider with a more daring design. Key innovations include available all-wheel drive for the first time and Nissan's ProPilot Assist semi-autonomous driving system. Engine options initially included a 188 hp 2.5-liter four-cylinder and a 248 hp turbocharged 2.0-liter four-cylinder (replacing the previous V6), both paired with a CVT. The 2023 model received styling updates and a newly available 12.3-inch touchscreen.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Nissan_Altima"
+
 generations:
   - name: "First Generation (U13)"
     start_year: 1993


### PR DESCRIPTION
- Added references array with Nissan Altima Wikipedia URL
- Updated README.md to standard template
- Retained comprehensive 6-generation data (1993-present)
- Note: Main Wikipedia article not accessible via local server; data documented in AMBIGUITIES.txt

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
